### PR TITLE
Added reference id to entities 

### DIFF
--- a/src/Data/AppDbContext.cs
+++ b/src/Data/AppDbContext.cs
@@ -23,6 +23,12 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     private static void ConfigureUsersTable(ModelBuilder modelBuilder)
     {
         var builder = modelBuilder.Entity<User>();
+
+        builder.HasIndex(x => x.Username)
+            .IsUnique();
+
+        builder.HasIndex(x => x.ReferenceId)
+            .IsUnique();
         
         builder.HasMany(x => x.Posts)
             .WithOne(x => x.User)
@@ -59,6 +65,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     {
         var builder = modelBuilder.Entity<Post>();
 
+        builder.HasIndex(x => x.ReferenceId)
+            .IsUnique();
+
         builder.Property(x => x.Title)
             .HasMaxLength(100);
 
@@ -76,6 +85,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     private static void ConfigureCommentsTable(ModelBuilder modelBuilder)
     {
         var builder = modelBuilder.Entity<Comment>();
+
+        builder.HasIndex(x => x.ReferenceId)
+            .IsUnique();
 
         builder.HasMany(x => x.Likes)
             .WithOne(x => x.Comment)

--- a/src/Data/Migrations/20240715103609_Init.Designer.cs
+++ b/src/Data/Migrations/20240715103609_Init.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Chirper.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20240714054511_Init")]
+    [Migration("20240715103609_Init")]
     partial class Init
     {
         /// <inheritdoc />
@@ -43,6 +43,9 @@ namespace Chirper.Data.Migrations
                     b.Property<int>("PostId")
                         .HasColumnType("int");
 
+                    b.Property<Guid>("ReferenceId")
+                        .HasColumnType("uniqueidentifier");
+
                     b.Property<int?>("ReplyToCommentId")
                         .HasColumnType("int");
 
@@ -55,6 +58,9 @@ namespace Chirper.Data.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("PostId");
+
+                    b.HasIndex("ReferenceId")
+                        .IsUnique();
 
                     b.HasIndex("ReplyToCommentId");
 
@@ -113,6 +119,9 @@ namespace Chirper.Data.Migrations
                     b.Property<DateTime>("CreatedAtUtc")
                         .HasColumnType("datetime2");
 
+                    b.Property<Guid>("ReferenceId")
+                        .HasColumnType("uniqueidentifier");
+
                     b.Property<string>("Title")
                         .IsRequired()
                         .HasMaxLength(100)
@@ -125,6 +134,9 @@ namespace Chirper.Data.Migrations
                         .HasColumnType("int");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("ReferenceId")
+                        .IsUnique();
 
                     b.HasIndex("UserId");
 
@@ -168,11 +180,20 @@ namespace Chirper.Data.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
+                    b.Property<Guid>("ReferenceId")
+                        .HasColumnType("uniqueidentifier");
+
                     b.Property<string>("Username")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("ReferenceId")
+                        .IsUnique();
+
+                    b.HasIndex("Username")
+                        .IsUnique();
 
                     b.ToTable("Users");
                 });

--- a/src/Data/Migrations/20240715103609_Init.cs
+++ b/src/Data/Migrations/20240715103609_Init.cs
@@ -17,7 +17,8 @@ namespace Chirper.Data.Migrations
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    Username = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ReferenceId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Username = table.Column<string>(type: "nvarchar(450)", nullable: false),
                     Password = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     DisplayName = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
@@ -56,6 +57,7 @@ namespace Chirper.Data.Migrations
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
+                    ReferenceId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Title = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
                     Content = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     UserId = table.Column<int>(type: "int", nullable: false),
@@ -78,6 +80,7 @@ namespace Chirper.Data.Migrations
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
+                    ReferenceId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     PostId = table.Column<int>(type: "int", nullable: false),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     Content = table.Column<string>(type: "nvarchar(max)", nullable: false),
@@ -162,6 +165,12 @@ namespace Chirper.Data.Migrations
                 column: "PostId");
 
             migrationBuilder.CreateIndex(
+                name: "IX_Comments_ReferenceId",
+                table: "Comments",
+                column: "ReferenceId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
                 name: "IX_Comments_ReplyToCommentId",
                 table: "Comments",
                 column: "ReplyToCommentId");
@@ -182,9 +191,27 @@ namespace Chirper.Data.Migrations
                 column: "UserId");
 
             migrationBuilder.CreateIndex(
+                name: "IX_Posts_ReferenceId",
+                table: "Posts",
+                column: "ReferenceId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
                 name: "IX_Posts_UserId",
                 table: "Posts",
                 column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_ReferenceId",
+                table: "Users",
+                column: "ReferenceId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Username",
+                table: "Users",
+                column: "Username",
+                unique: true);
         }
 
         /// <inheritdoc />

--- a/src/Data/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Data/Migrations/AppDbContextModelSnapshot.cs
@@ -40,6 +40,9 @@ namespace Chirper.Data.Migrations
                     b.Property<int>("PostId")
                         .HasColumnType("int");
 
+                    b.Property<Guid>("ReferenceId")
+                        .HasColumnType("uniqueidentifier");
+
                     b.Property<int?>("ReplyToCommentId")
                         .HasColumnType("int");
 
@@ -52,6 +55,9 @@ namespace Chirper.Data.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("PostId");
+
+                    b.HasIndex("ReferenceId")
+                        .IsUnique();
 
                     b.HasIndex("ReplyToCommentId");
 
@@ -110,6 +116,9 @@ namespace Chirper.Data.Migrations
                     b.Property<DateTime>("CreatedAtUtc")
                         .HasColumnType("datetime2");
 
+                    b.Property<Guid>("ReferenceId")
+                        .HasColumnType("uniqueidentifier");
+
                     b.Property<string>("Title")
                         .IsRequired()
                         .HasMaxLength(100)
@@ -122,6 +131,9 @@ namespace Chirper.Data.Migrations
                         .HasColumnType("int");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("ReferenceId")
+                        .IsUnique();
 
                     b.HasIndex("UserId");
 
@@ -165,11 +177,20 @@ namespace Chirper.Data.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
+                    b.Property<Guid>("ReferenceId")
+                        .HasColumnType("uniqueidentifier");
+
                     b.Property<string>("Username")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("ReferenceId")
+                        .IsUnique();
+
+                    b.HasIndex("Username")
+                        .IsUnique();
 
                     b.ToTable("Users");
                 });

--- a/src/Data/Types/Comment.cs
+++ b/src/Data/Types/Comment.cs
@@ -3,6 +3,7 @@
 public class Comment : IEntity, IOwnedEntity
 {
     public int Id { get; private set; }
+    public Guid ReferenceId { get; private init; } = Guid.NewGuid();
     public required int PostId { get; init; }
     public Post Post { get; init; } = null!;
     public required int UserId { get; init; }

--- a/src/Data/Types/IEntity.cs
+++ b/src/Data/Types/IEntity.cs
@@ -3,6 +3,7 @@
 public interface IEntity
 {
     int Id { get; }
+    Guid ReferenceId { get; }
 }
 
 public interface IOwnedEntity

--- a/src/Data/Types/Post.cs
+++ b/src/Data/Types/Post.cs
@@ -3,6 +3,7 @@
 public class Post : IEntity, IOwnedEntity
 {
     public int Id { get; private set; }
+    public Guid ReferenceId { get; private init; } = Guid.NewGuid();
     public required string Title { get; set; }
     public string? Content { get; set; }
     public required int UserId { get; init; }

--- a/src/Data/Types/User.cs
+++ b/src/Data/Types/User.cs
@@ -3,6 +3,7 @@
 public class User : IEntity
 {
     public int Id { get; private init; }
+    public Guid ReferenceId { get; private init; } = Guid.NewGuid();
     public required string Username { get; set; }
     public required string Password { get; set; }
     public required string DisplayName { get; set; }


### PR DESCRIPTION
Added reference id to entities so they can be referenced in application events during a transaction. Its another unique identifier but we still want numbers as our clustered index as the primary key